### PR TITLE
Update documentation and add requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .history
 *.txt
 *.tsv
+!requirements.txt

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Cygwin is the recommended method of running cbrcli on windows as it will have al
 
 * Install Cygwin from https://cygwin.com/install.html
 * When installing Cygwin, ensure that the python and python pip packages are selected for installation
-* This version have now cbapi included under /Submodules/cbapi-python and does not require it to be installed with pip install cbapi.
+* Install dependencies with `pip install -r requirements.txt`.
 * Download and extract cbrcli from the github page (https://github.com/jtwiborg/cbrcli-jtwiborg.git)  (Original found here: https://github.com/ctxis/cbrcli)
 * Navigate to the downloaded directory in cygwin, likely somewhere in /cygdrive/c/Users/yourusername/
 * Follow the instructions here https://cbapi.readthedocs.io/en/latest/#api-credentials to set up your credentials
-* Start cbrcli with `python cbrcli.py`
+* Start cbrcli with `python3 cbrcli.py`
 
 Method 2: Windows cmd
 This method will work and is slightly simpler than the cygwin method, however the experience will not be as smooth and you won't get advantages like coloured output.
@@ -40,8 +40,9 @@ Installation on Linux should be much simpler than Windows.
 
 * Install python3 for your Linux distribution or by venv, conda or other.
 * Download and extract https://github.com/jtwiborg/cbrcli-jtwiborg.git from github  (Original found here: https://github.com/ctxis/cbrcli)
+* Install dependencies with `pip install -r requirements.txt`
 * Follow the instructions here https://cbapi.readthedocs.io/en/latest/#api-credentials to set up your credentials
-* cd into the cbrcli directory and run with `python cbrcli.py`
+* cd into the cbrcli directory and run with `python3 cbrcli.py`
 
 ## In-program Help
 

--- a/cbrcli.py
+++ b/cbrcli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import (division, print_function, absolute_import, unicode_literals)
 
-VERSION = 'cbrcli version 1.7.8 (Plutonium Eggplant)'
+VERSION = 'cbrcli version 1.8.0 (Plutonium Eggplant)'
 print(VERSION)
 import os
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+cachetools==6.0.0
+cbapi==2.0.0
+certifi==2025.4.26
+charset-normalizer==3.4.2
+pika==1.3.2
+prompt_toolkit==3.0.51
+protobuf==6.31.1
+Pygments==2.19.1
+python-dateutil==2.9.0.post0
+PyYAML==6.0.2
+requests==2.32.3
+six==1.17.0
+solrq==1.1.2
+urllib3==2.4.0
+validators==0.35.0
+wcwidth==0.2.13


### PR DESCRIPTION
## Summary
- document installing dependencies via pip
- standardize on `python3` command usage
- require dependencies file for easy setup
- update version string to 1.8.0

## Testing
- `python3 cbrcli.py -h | head -n 5`
- `python3 -m py_compile cbrcli.py`


------
https://chatgpt.com/codex/tasks/task_e_68444f0e0a28832e8b6f4d80566187b9