### PR TITLE
Add numbered sibling results

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I found this tool to be very good, however a bit old and with old dependencies. 
 Things that have been updated:
 * python3 ready
 * New commands.
-  * `siblings` command for listing sibling processes
+* `siblings` command for listing sibling processes (results are numbered and can be inspected)
 
 ## Installing
 


### PR DESCRIPTION
## Summary
- initialize sibling context
- number sibling results and keep them accessible
- allow selecting siblings by number
- document new numbering behavior

## Testing
- `python3 -m py_compile cbrcli.py`

------
https://chatgpt.com/codex/tasks/task_e_6844af0ef314832ea2f987ac4c79312a