### PR TITLE
Add alert mode to cbrcli

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Things that have been updated:
 * python3 ready
 * New commands.
 * `siblings` command for listing sibling processes (results are numbered and can be inspected)
+* `alert` mode for querying watchlist and feed alerts
 
 ## Installing
 
@@ -57,12 +58,14 @@ search parent_name:winword.exe AND process_name:powershell.exe
 filter netconn_count:[1 TO *]
 ```
 
-## Switching between Process and Binary Modes
+## Switching between Process, Binary, Sensor and Alert Modes
 
-cbrcli has two `modes` which determine whether to query for processes or binaries. The currently selected mode is displayed in the prompt and can be changed using the `mode` command followed by either `process` or `binary`. There is no difference to any of the commands you can perform between the two modes, however there will be different search terms available. The autocomplete functionality will only suggest valid fields for the current mode, for example `process_name` will only be available in `process` mode.
+cbrcli supports multiple `modes` which determine what type of objects are queried. The currently selected mode is displayed in the prompt and can be changed using the `mode` command followed by `process`, `binary`, `sensor` or `alert`. Each mode has a different set of search terms available. The autocomplete functionality will only suggest valid fields for the current mode, for example `process_name` will only be available in `process` mode.
 ```
 mode binary
 mode process
+mode sensor
+mode alert
 ```
 
 ## Displaying and Viewing Results

--- a/cbrcli.py
+++ b/cbrcli.py
@@ -16,7 +16,7 @@ import time
 import subprocess
 from hashlib import md5
 from datetime import datetime, timedelta
-from cbapi.response import CbResponseAPI, Process, Binary, Feed, Sensor
+from cbapi.response import CbResponseAPI, Process, Binary, Feed, Sensor, Alert
 from cbapi.live_response_api import LiveResponseError
 from cbapi.errors import ServerError, CredentialError, ApiError
 from threading import Thread
@@ -134,7 +134,88 @@ modes = {
             'ipaddr',
             'regmod',
             'filemod',
-            'webui_link',
+        'webui_link',
+        ]
+    },
+    'alert': {
+        'object': Alert,
+        'name': 'alert',
+        'sort_field': 'created_time desc',
+        'sortable_fields': ['created_time', 'alert_severity', 'report_score'],
+        'default_fieldset': ['hostname', 'process_name', 'alert_type', 'status'],
+        'search_fields': [
+            'alert_severity',
+            'alert_type',
+            'assigned_to',
+            'create_time',
+            'created_time',
+            'description',
+            'domain',
+            'feed_category',
+            'feed_id',
+            'feed_name',
+            'group',
+            'hostname',
+            'ioc_value',
+            'ipaddr',
+            'ipv6addr',
+            'is_ignored',
+            'md5',
+            'observed_filename',
+            'process_name',
+            'process_path',
+            'report_id',
+            'report_score',
+            'resolved_time',
+            'sha256',
+            'status',
+            'tags',
+            'title',
+            'update_time',
+            'username',
+            'watchlist_id',
+            'watchlist_name',
+        ],
+        'fields': [
+            'username',
+            'alert_type',
+            'sensor_criticality',
+            'modload_count',
+            'report_score',
+            'watchlist_id',
+            'sensor_id',
+            'feed_name',
+            'created_time',
+            'report_ignored',
+            'ioc_type',
+            'watchlist_name',
+            'ioc_confidence',
+            'alert_severity',
+            'crossproc_count',
+            'group',
+            'hostname',
+            'filemod_count',
+            'comms_ip',
+            'netconn_count',
+            'interface_ip',
+            'status',
+            'process_path',
+            'description',
+            'process_name',
+            'process_unique_id',
+            'process_id',
+            'link',
+            '_version_',
+            'regmod_count',
+            'md5',
+            'segment_id',
+            'total_hosts',
+            'feed_id',
+            'ioc_value',
+            'os_type',
+            'childproc_count',
+            'unique_id',
+            'feed_rating',
         ]
     },
     'sensor': {
@@ -301,6 +382,8 @@ with open(os.sep.join((config_dir, fieldset_file))) as fieldsets, open(os.sep.jo
 if not state['fieldsets']['process'].get('current'):
     state['fieldsets']['process']['current'] = state['fieldsets']['process']['default']
     state['fieldsets']['binary']['current'] = state['fieldsets']['binary']['default']
+    state['fieldsets']['sensor']['current'] = state['fieldsets']['sensor']['default']
+    state['fieldsets']['alert']['current'] = state['fieldsets']['alert']['default']
 
 for mode in modes:
     if not state['filters'].get(mode):
@@ -330,7 +413,7 @@ def color(s, c):
 
 commands = {
     'version': "version\tPrint cbcli version",
-    'mode': "mode <mode>\tSwitch to different search mode (most be one of: process, binary, sensor)",
+    'mode': "mode <mode>\tSwitch to different search mode (most be one of: process, binary, sensor, alert)",
     'search': "search <CB query string>\tSearch carbon black server",
     'filter': "filter <CB query string>\tFurther filter search query",
     'bfilter': "bfilter <CB query string>\tReplace previous filter with this one",


### PR DESCRIPTION
## Summary
- add new **alert** mode with its own fields
- include alert mode in config setup and help text
- document alert mode in README

## Testing
- `python3 -m py_compile cbrcli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f24cc9b8832eaf61a2459f965b6e